### PR TITLE
Add wrapping styles for long headings

### DIFF
--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -53,15 +53,19 @@ p {
 }
 
 .site-hed {
-  background: #2e2e2e;
   color: #fff;
   display: inline-block;
   font-size: 2.8em;
   padding: .2em .4em;
   margin: 0 0 .25em 0;
-  white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
+
+  span {
+    background: #2e2e2e;
+    box-shadow: .4em 0 0 #2e2e2e, -.4em 0 0 #2e2e2e;
+    line-height: 1.5;
+    padding: .2em 0;
+  }
 }
 @media (max-width: 44.9375em) {
   .site-hed {

--- a/tpl/.api-content.html
+++ b/tpl/.api-content.html
@@ -35,7 +35,7 @@
     </nav>
 
     <header role="banner" class="banner">
-     <h1 class="site-hed"><%= title %></h1>
+     <h1 class="site-hed"><span><%= title %></span></h1>
     </header>
   </div>
 

--- a/tpl/.api.html
+++ b/tpl/.api.html
@@ -35,7 +35,7 @@
     </nav>
 
     <header role="banner" class="banner">
-     <h1 class="site-hed">API Documentation</h1>
+     <h1 class="site-hed"><span>API Documentation</span></h1>
     </header>
   </div>
 

--- a/tpl/.articles.html
+++ b/tpl/.articles.html
@@ -35,7 +35,7 @@
     </nav>
 
     <header role="banner" class="banner">
-     <h1 class="site-hed">Articles</h1>
+     <h1 class="site-hed"><span>Articles</span></h1>
     </header>
   </div>
 

--- a/tpl/.example-content.html
+++ b/tpl/.example-content.html
@@ -35,7 +35,7 @@
     </nav>
 
     <header role="banner" class="banner">
-     <h1 class="site-hed"><%= title %></h1>
+     <h1 class="site-hed"><span><%= title %></span></h1>
     </header>
   </div>
 

--- a/tpl/.examples.html
+++ b/tpl/.examples.html
@@ -35,7 +35,7 @@
     </nav>
 
     <header role="banner" class="banner">
-     <h1 class="site-hed">Examples</h1>
+     <h1 class="site-hed"><span>Examples</span></h1>
     </header>
   </div>
 

--- a/tpl/.index.html
+++ b/tpl/.index.html
@@ -36,7 +36,7 @@
     </nav>
 
     <header role="banner" class="banner banner-home">
-      <h1 class="site-hed">Johnny-Five</h1>
+      <h1 class="site-hed"><span>Johnny-Five</span></h1>
       <p role="marquee" aria-live="polite" class="site-subhed">The JavaScript<br/><span class="js-board-type">Arduino</span> Programming Framework</p>
 
       <p role="marquee" aria-live="polite" class="site-subhed" id="visit-mike">Artwork by<br/>

--- a/tpl/.news-content.html
+++ b/tpl/.news-content.html
@@ -36,7 +36,7 @@
     </nav>
 
     <header role="banner" class="banner">
-     <h1 class="site-hed"><%= title %></h1>
+     <h1 class="site-hed"><span><%= title %></span></h1>
     </header>
   </div>
 

--- a/tpl/.news.html
+++ b/tpl/.news.html
@@ -35,7 +35,7 @@
     </nav>
 
     <header role="banner" class="banner">
-     <h1 class="site-hed">News</h1>
+     <h1 class="site-hed"><span>News</span></h1>
     </header>
   </div>
 

--- a/tpl/.platform-support.html
+++ b/tpl/.platform-support.html
@@ -34,7 +34,7 @@
     </nav>
 
     <header role="banner" class="banner">
-     <h1 class="site-hed">Platform Support</h1>
+     <h1 class="site-hed"><span>Platform Support</span></h1>
     </header>
   </div>
 


### PR DESCRIPTION
Long headings, especially in the news section, weren't being allowed to wrap.

Before:
![screen shot 2015-08-25 at 9 13 06 pm](https://cloud.githubusercontent.com/assets/1072711/9483450/8941fe68-4b6e-11e5-8d2e-01c3827f4046.png)

After:
![screen shot 2015-08-25 at 9 13 32 pm](https://cloud.githubusercontent.com/assets/1072711/9483451/895874b8-4b6e-11e5-9589-9efc03159aec.png)
