### PR TITLE
Add the tessel 2 to the platform cycler dry up the header

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,6 +25,7 @@ module.exports = function(grunt) {
   var template = grunt.template;
   var _ = grunt.util._;
 
+  var header = file.read("tpl/.header.html");
   var footer = file.read("tpl/.footer.html");
   var navigation = file.read("tpl/.navigation.html");
   var egPrograms;
@@ -374,6 +375,7 @@ module.exports = function(grunt) {
     file.write("public/index.html", templates.index({
       navigation: navigation,
       platforms: markdown.render(platforms),
+      header: header,
       footer: footer
     }));
   });
@@ -389,6 +391,7 @@ module.exports = function(grunt) {
     var rendered = "";
     var articles = {
       navigation: navigation,
+      header: header,
       footer: footer
     };
 
@@ -437,6 +440,7 @@ module.exports = function(grunt) {
     file.write("public/examples/index.html", templates.examples({
       navigation: navigation,
       list: markdown.render(examples),
+      header: header,
       footer: footer
     }));
   });
@@ -490,6 +494,7 @@ module.exports = function(grunt) {
         file.write(outpath, templates.exampleContent({
           apilist: markdown.render(apilist),
           contents: contents,
+          header: header,
           footer: footer,
           list: markdown.render(examples),
           navigation: navigation,
@@ -563,6 +568,7 @@ module.exports = function(grunt) {
           remove(source)
         ),
         examples: markdown.render(examples),
+        header: header,
         footer: footer
       }));
     });
@@ -571,6 +577,7 @@ module.exports = function(grunt) {
       navigation: navigation,
       list: list,
       guides: markdown.render(guides),
+      header: header,
       footer: footer
     }));
   });
@@ -631,6 +638,7 @@ module.exports = function(grunt) {
         list: list,
         title: source.title,
         contents: contents,
+        header: header,
         footer: footer
       }));
     });
@@ -639,6 +647,7 @@ module.exports = function(grunt) {
       navigation: navigation,
       list: list,
       latest: latest,
+      header: header,
       footer: footer
     }));
   });
@@ -712,6 +721,7 @@ module.exports = function(grunt) {
       navigation: navigation,
       platforms: markdown.render(platforms),
       contents: contents,
+      header: header,
       footer: footer
     }));
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -67,6 +67,7 @@
   var index = 1;
   var platforms = [
     "Arduino",
+    "Tessel 2",
     "BeagleBone",
     "BlendMicro",
     "Electric Imp",

--- a/tpl/.api-content.html
+++ b/tpl/.api-content.html
@@ -3,29 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>JavaScript Robotics: <%= title %> API (Johnny-Five)</title>
-  <meta name="description" content="Johnny-Five is the JavaScript Robotics programming framework">
-  <meta name="keywords" content="JavaScript, Robotics">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="fonts" content="/css/type.css">
-
   <meta property="og:title" content="JavaScript Robotics: <%= title %> API (Johnny-Five)">
-  <meta property="og:site_name" content="Johnny-Five">
-  <meta property="og:image" content="http://johnny-five.io/img/static/johnny-five-fb.png">
-  <meta property="og:description" content="Johnny-Five is the original JavaScript Robotics programming framework. Released by Bocoup in 2012, Johnny-Five is maintained by a community of passionate software developers and hardware engineers. Over 75 developers have made contributions towards building a robust, extensible and composable ecosystem.">
-
-  <script src="/js/fontloader.js" id="fontloader"></script>
-  <script src="/js/anchor.js" id="anchor.js"></script>
-  <script src="/js/es6-shim.js" id="es6-shim.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-
-  <link rel="stylesheet" href="/css/styles.css">
-  <link rel="stylesheet" href="/css/anchor.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-
-  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-
+  <%= header %>
 </head>
 <body>
 

--- a/tpl/.api.html
+++ b/tpl/.api.html
@@ -3,29 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>JavaScript Robotics API Documentation (Johnny-Five)</title>
-  <meta name="description" content="Johnny-Five is the JavaScript robotics programming framework">
-  <meta name="keywords" content="JavaScript, Robotics">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="fonts" content="/css/type.css">
-
   <meta property="og:title" content="JavaScript Robotics API Documentation (Johnny-Five)">
-  <meta property="og:site_name" content="Johnny-Five">
-  <meta property="og:image" content="http://johnny-five.io/img/static/johnny-five-fb.png">
-  <meta property="og:description" content="Johnny-Five is the original JavaScript Robotics programming framework. Released by Bocoup in 2012, Johnny-Five is maintained by a community of passionate software developers and hardware engineers. Over 75 developers have made contributions towards building a robust, extensible and composable ecosystem.">
-
-  <script src="/js/fontloader.js" id="fontloader"></script>
-  <script src="/js/anchor.js" id="anchor.js"></script>
-  <script src="/js/es6-shim.js" id="es6-shim.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-
-  <link rel="stylesheet" href="/css/styles.css">
-  <link rel="stylesheet" href="/css/anchor.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-
-  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-
+  <%= header %>
 </head>
 <body>
 
@@ -44,7 +23,6 @@
 
       <div class="docs-content docs-guides">
         <h3>Guides</h3>
-
         <%= guides %>
       </div>
 

--- a/tpl/.articles.html
+++ b/tpl/.articles.html
@@ -3,29 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>JavaScript Robotics Articles (Johnny-Five)</title>
-  <meta name="description" content="Johnny-Five is the JavaScript robotics programming framework">
-  <meta name="keywords" content="JavaScript, Robotics">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="fonts" content="/css/type.css">
-
   <meta property="og:title" content="JavaScript Robotics Articles (Johnny-Five)">
-  <meta property="og:site_name" content="Johnny-Five">
-  <meta property="og:image" content="http://johnny-five.io/img/static/johnny-five-fb.png">
-  <meta property="og:description" content="Johnny-Five is the original JavaScript Robotics programming framework. Released by Bocoup in 2012, Johnny-Five is maintained by a community of passionate software developers and hardware engineers. Over 75 developers have made contributions towards building a robust, extensible and composable ecosystem.">
-
-  <script src="/js/fontloader.js" id="fontloader"></script>
-  <script src="/js/anchor.js" id="anchor.js"></script>
-  <script src="/js/es6-shim.js" id="es6-shim.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-
-  <link rel="stylesheet" href="/css/styles.css">
-  <link rel="stylesheet" href="/css/anchor.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-
-  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-
+  <%= header %>
 </head>
 <body>
 
@@ -209,7 +188,7 @@
 
       <h3><a href="http://www.reddit.com/r/NodeBots/">Reddit</a></h3>
 
-      <%=reddit%>
+      <%= reddit %>
 
     </div>
   </main>

--- a/tpl/.example-content.html
+++ b/tpl/.example-content.html
@@ -3,29 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>JavaScript Robotics: <%= title %> with Johnny-Five</title>
-  <meta name="description" content="Johnny-Five is the JavaScript robotics programming framework">
-  <meta name="keywords" content="JavaScript, Robotics">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="fonts" content="/css/type.css">
-
   <meta property="og:title" content="JavaScript Robotics: <%= title %> (Johnny-Five)">
-  <meta property="og:site_name" content="Johnny-Five">
-  <meta property="og:image" content="<%= ogImage %>">
-  <meta property="og:description" content="<%= title %> with Johnny-Five. Johnny-Five is the original JavaScript Robotics programming framework. Released by Bocoup in 2012, Johnny-Five is maintained by a community of passionate software developers and hardware engineers. Over 75 developers have made contributions towards building a robust, extensible and composable ecosystem.">
-
-  <script src="/js/fontloader.js" id="fontloader"></script>
-  <script src="/js/anchor.js" id="anchor.js"></script>
-  <script src="/js/es6-shim.js" id="es6-shim.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-
-  <link rel="stylesheet" href="/css/styles.css">
-  <link rel="stylesheet" href="/css/anchor.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-
-  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-
+  <%= header %>
 </head>
 <body>
 

--- a/tpl/.examples.html
+++ b/tpl/.examples.html
@@ -3,29 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>JavaScript Robotics Examples (Johnny-Five)</title>
-  <meta name="description" content="Johnny-Five is the JavaScript robotics programming framework">
-  <meta name="keywords" content="JavaScript, Robotics">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="fonts" content="/css/type.css">
-
   <meta property="og:title" content="JavaScript Robotics Examples (Johnny-Five">
-  <meta property="og:site_name" content="Johnny-Five">
-  <meta property="og:image" content="http://johnny-five.io/img/static/johnny-five-fb.png">
-  <meta property="og:description" content="Johnny-Five is the original JavaScript Robotics programming framework. Released by Bocoup in 2012, Johnny-Five is maintained by a community of passionate software developers and hardware engineers. Over 75 developers have made contributions towards building a robust, extensible and composable ecosystem.">
-
-  <script src="/js/fontloader.js" id="fontloader"></script>
-  <script src="/js/anchor.js" id="anchor.js"></script>
-  <script src="/js/es6-shim.js" id="es6-shim.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-
-  <link rel="stylesheet" href="/css/styles.css">
-  <link rel="stylesheet" href="/css/anchor.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-
-  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-
+  <%= header %>
 </head>
 <body>
 

--- a/tpl/.header.html
+++ b/tpl/.header.html
@@ -1,0 +1,20 @@
+  <meta name="description" content="Johnny-Five is the JavaScript robotics programming framework">
+  <meta name="keywords" content="JavaScript, Robotics">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="fonts" content="/css/type.css">
+
+  <meta property="og:site_name" content="Johnny-Five">
+  <meta property="og:image" content="http://johnny-five.io/img/static/johnny-five-fb.png">
+  <meta property="og:description" content="Johnny-Five is the original JavaScript Robotics programming framework. Released by Bocoup in 2012, Johnny-Five is maintained by a community of passionate software developers and hardware engineers. Over 75 developers have made contributions towards building a robust, extensible and composable ecosystem.">
+
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="/css/anchor.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
+
+  <script src="/js/fontloader.js" id="fontloader"></script>
+  <script src="/js/anchor.js" id="anchor.js"></script>
+  <script src="/js/es6-shim.js" id="es6-shim.js"></script>
+
+  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">

--- a/tpl/.index.html
+++ b/tpl/.index.html
@@ -3,31 +3,10 @@
 <head>
   <meta charset="utf-8">
   <title>Johnny-Five: The JavaScript Robotics Programming Framework</title>
-  <meta name="description" content="Johnny-Five is the JavaScript Robotics Programming Framework">
-  <meta name="keywords" content="JavaScript, Robotics">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="fonts" content="/css/type.css">
-
   <meta property="og:title" content="Johnny-Five is the JavaScript Robotics Programming Framework" />
-  <meta property="og:site_name" content="Johnny-Five">
+  <%= header %>
   <meta property="og:url" content="http://johnny-five.io/">
-  <meta property="og:image" content="http://johnny-five.io/img/static/johnny-five-fb.png">
-  <meta property="og:description" content="Johnny-Five is the original JavaScript Robotics programming framework. Released by Bocoup in 2012, Johnny-Five is maintained by a community of passionate software developers and hardware engineers. Over 75 developers have made contributions towards building a robust, extensible and composable ecosystem.">
-
-  <script src="/js/fontloader.js" id="fontloader"></script>
-  <script src="/js/anchor.js" id="anchor.js"></script>
-  <script src="/js/es6-shim.js" id="es6-shim.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-
-  <link rel="stylesheet" href="/css/styles.css">
-  <link rel="stylesheet" href="/css/anchor.css">
   <link rel="stylesheet" href="/css/magic.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-
-  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-
 </head>
 <body>
 
@@ -50,8 +29,6 @@
         <img class="j5" srcset="img/heres-johnny.png" alt="Artwork by Mike Sgier, http://msgierillustration.com/">
         <img class="j5" srcset="img/trick-or-treat.png" style="opacity: 0">
       </span>
-
-
     </header>
   </div>
 

--- a/tpl/.news-content.html
+++ b/tpl/.news-content.html
@@ -3,30 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>Johnny-Five.io: <%= title %></title>
-  <meta name="description" content="Johnny-Five is the JavaScript Robotics programming framework">
-  <meta name="keywords" content="JavaScript, Robotics">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="fonts" content="/css/type.css">
-
   <meta property="og:title" content="Johnny-Five.io: <%= title %>">
-  <meta property="og:site_name" content="Johnny-Five">
-  <meta property="og:image" content="http://johnny-five.io/img/static/johnny-five-fb.png">
-  <meta property="og:type" content="article">
-  <meta property="og:description" content="Johnny-Five is the original JavaScript Robotics programming framework. Released by Bocoup in 2012, Johnny-Five is maintained by a community of passionate software developers and hardware engineers. Over 75 developers have made contributions towards building a robust, extensible and composable ecosystem.">
-
-  <script src="/js/fontloader.js" id="fontloader"></script>
-  <script src="/js/anchor.js" id="anchor.js"></script>
-  <script src="/js/es6-shim.js" id="es6-shim.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-
-  <link rel="stylesheet" href="/css/styles.css">
-  <link rel="stylesheet" href="/css/anchor.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-
-  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-
+  <%= header %>
 </head>
 <body>
 

--- a/tpl/.news.html
+++ b/tpl/.news.html
@@ -3,29 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>JavaScript Robotics News (Johnny-Five)</title>
-  <meta name="description" content="Johnny-Five is the JavaScript Robotics programming framework">
-  <meta name="keywords" content="JavaScript, Robotics">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="fonts" content="/css/type.css">
-
   <meta property="og:title" content="JavaScript Robotics News (Johnny-Five)">
-  <meta property="og:site_name" content="Johnny-Five">
-  <meta property="og:image" content="http://johnny-five.io/img/static/johnny-five-fb.png">
-  <meta property="og:description" content="Johnny-Five is the original JavaScript Robotics programming framework. Released by Bocoup in 2012, Johnny-Five is maintained by a community of passionate software developers and hardware engineers. Over 75 developers have made contributions towards building a robust, extensible and composable ecosystem.">
-
-  <script src="/js/fontloader.js" id="fontloader"></script>
-  <script src="/js/anchor.js" id="anchor.js"></script>
-  <script src="/js/es6-shim.js" id="es6-shim.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-
-  <link rel="stylesheet" href="/css/styles.css">
-  <link rel="stylesheet" href="/css/anchor.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-
-  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-
+  <%= header %>
 </head>
 <body>
 

--- a/tpl/.platform-support.html
+++ b/tpl/.platform-support.html
@@ -3,28 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>JavaScript Robotics Platform Support (Johnny-Five)</title>
-  <meta name="description" content="Johnny-Five is the JavaScript robotics programming framework">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="fonts" content="/css/type.css">
-
   <meta property="og:title" content="JavaScript Robotics Platform Support (Johnny-Five)">
-  <meta property="og:site_name" content="Johnny-Five">
-  <meta property="og:image" content="http://johnny-five.io/img/static/johnny-five-fb.png">
-  <meta property="og:description" content="Johnny-Five is the original JavaScript Robotics programming framework. Released by Bocoup in 2012, Johnny-Five is maintained by a community of passionate software developers and hardware engineers. Over 75 developers have made contributions towards building a robust, extensible and composable ecosystem.">
-
-  <script src="/js/fontloader.js" id="fontloader"></script>
-  <script src="/js/anchor.js" id="anchor.js"></script>
-  <script src="/js/es6-shim.js" id="es6-shim.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-
-  <link rel="stylesheet" href="/css/styles.css">
-  <link rel="stylesheet" href="/css/anchor.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-
-  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
-
+  <%= header %>
 </head>
 <body>
 


### PR DESCRIPTION
I noticed we were loading the syntax highlighting js file twice so I went to take it out and ended up making a template for the header