### PR TITLE
Update hookshot to do tag-based deployment

### DIFF
--- a/.hookshot.conf
+++ b/.hookshot.conf
@@ -5,6 +5,6 @@ method = "ansible"
 playbook = "deploy/ansible/deploy.yml"
 inventory = "deploy/ansible/inventory/staging"
 
-[branch.production]
+[tag."prod-*"]
 playbook = "deploy/ansible/deploy.yml"
 inventory = "deploy/ansible/inventory/production"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ brew install node
 gem install sass
 ```
 
-## Setup 
+## Setup
 
 ```
 npm install
@@ -32,22 +32,22 @@ Content displayed on johnny-five.io is sourced from two other repos:
 - [https://github.com/rwaldron/johnny-five.wiki.git](https://github.com/rwaldron/johnny-five/wiki)
     + API Documentation
 
-The content is consumed and processed via grunt tasks that output the website-ready versions of the content to the `public/` directory. 
+The content is consumed and processed via grunt tasks that output the website-ready versions of the content to the `public/` directory.
 
 -------
-Bootstrap site content from remote repos: 
+Bootstrap site content from remote repos:
 
 ```
 grunt bootstrap
 ```
 
-Regenerate all local content from remote content sources: 
+Regenerate all local content from remote content sources:
 
 ```
 grunt regen
 ```
 
-Development automation and server: 
+Development automation and server:
 
 ```
 grunt && grunt dev
@@ -59,53 +59,53 @@ grunt && grunt dev
     + `dev` Run the `connect`, `launch`, and `watch` tasks.
         * `connect`: connect the server
         * `launch`: open the site in a browser
-        * 
+        *
     + `bootstrap`: Run the `clean:deps`, `gitclone` and `copy` tasks.
         * Clean out remote content source dependencies and clone the the latest master branch of the johnny-five and johnny-five.wiki repos into the `src/` directory. Copy static resources to `public/`
     + `regen` Run `index`, `articles-from-rss`, `examples-list`, `examples`, `api-docs` and `platform-support` tasks.
     + `index` generates `public/index.html`
-        * Materials & Sources: 
+        * Materials & Sources:
             - `src/platforms-plugins.json`
             - `src/tpl/.index.html`
             - `src/css/style.scss`
             - `src/img/*`
             - `src/img/platforms/*`
-    + `articles-from-rss` generates article lists from a given set of rss feed targets. 
-        * Materials & Sources: 
+    + `articles-from-rss` generates article lists from a given set of rss feed targets.
+        * Materials & Sources:
             - `tpl/.articles.html`
             - `tpl/rss-list.html`
     + `examples-list` generates `public/examples.html`
-        * Materials & Sources: 
+        * Materials & Sources:
             - `tpl/.examples.html`
             - `src/johnny-five/README.md`
     + `examples` generates `public/examples/*.html`
-        * Materials & Sources: 
+        * Materials & Sources:
             - `tpl/.example-content.html`
             - `src/johnny-five/README.md`
             - `src/johnny-five/tpl/programs.json`
             - `src/johnny-five/tpl/titles.json`
             - `src/johnny-five/docs/breadboard/*.png`
     + `api-docs` generates `public/api.html` and `public/api/*.html`
-        * Materials & Sources: 
+        * Materials & Sources:
             - `tpl/.api.html`
             - `tpl/.api-content.html`
             - `src/johnny-five.wiki/Home.md`
             - `src/johnny-five.wiki/[API PAGES].md`
             - `src/johnny-five/docs/breadboard/*.png`
-    + `platform-support` generates `public/platform-support.html` 
-        * Materials & Sources: 
+    + `platform-support` generates `public/platform-support.html`
+        * Materials & Sources:
             - `tpl/.platform-support.html`
             - `tpl/.platform-variant.html`
             - `src/platforms-plugins.json`
             - Images in `src/img/platforms/`
                 + 500x500 PNG
                 + 270 pixels/inch
-                    * This is the Fritzing default, it looks nice on retina displays. 
-                    
+                    * This is the Fritzing default, it looks nice on retina displays.
+
 
 ## Continuous Deployment
 
-Merging or resetting `production` will automatically trigger a deploy to johnny-five.io, and merging to `master` will deploy to staging.johnny-five.io.
+Tagging a release with the prefix `prod-` (e.g. `prod-v123` or `prod-1450284359`) will automatically trigger a deploy to johnny-five.io. Merging to `master` will deploy to staging.johnny-five.io.
 
 In the (hopefully) rare instance you need to manually deploy the steps are below.
 


### PR DESCRIPTION
`master` -> `staging`
Any tag -> `production`.

An alternative would be to limit it so tags with a specific prefix deploy, e.g. `[tag."prod-*"]` would deploy on `prod-123` but not `some-other-tag`.